### PR TITLE
Update plugin for WordPress.com deployment compatibility

### DIFF
--- a/treasury-tech-portal.php
+++ b/treasury-tech-portal.php
@@ -1,31 +1,39 @@
 <?php
-/*
-Plugin Name: Treasury Tech Portal
-Description: Embed the Treasury Tech Portal tool using the [treasury_portal] shortcode. A comprehensive platform for discovering and comparing treasury technology solutions.
-Version: 1.0.0
-Author: Real Treasury
-Author URI: https://realtreasury.com
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: treasury-tech-portal
-Domain Path: /languages
-Requires at least: 5.0
-Tested up to: 6.4
-Requires PHP: 7.4
-Network: false
-*/
+/**
+ * Plugin Name: Treasury Tech Portal
+ * Plugin URI: https://realtreasury.com
+ * Description: Embed the Treasury Tech Portal tool using the [treasury_portal] shortcode. A comprehensive platform for discovering and comparing treasury technology solutions.
+ * Version: 1.0.0
+ * Requires at least: 5.0
+ * Requires PHP: 7.4
+ * Author: Real Treasury
+ * Author URI: https://realtreasury.com
+ * Text Domain: treasury-tech-portal
+ * Domain Path: /languages
+ * License: GPL v2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Network: false
+ */
 
-// Exit if accessed directly
-if (!defined('ABSPATH')) {
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Plugin version
-define('TTP_VERSION', '1.0.0');
-define('TTP_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('TTP_PLUGIN_DIR', plugin_dir_path(__FILE__));
-define('TTP_PLUGIN_BASENAME', plugin_basename(__FILE__));
+// Plugin version.
+define( 'TTP_VERSION', '1.0.0' );
 
-require_once plugin_dir_path(__FILE__) . 'includes/class-treasury-portal.php';
+define( 'TTP_FILE', __FILE__ );
+define( 'TTP_BASENAME', plugin_basename( TTP_FILE ) );
+define( 'TTP_URL', plugin_dir_url( TTP_FILE ) );
+define( 'TTP_DIR', plugin_dir_path( TTP_FILE ) );
+
+define( 'TTP_IS_WPCOM', defined( 'IS_WPCOM' ) && IS_WPCOM );
+
+require_once TTP_DIR . 'includes/class-treasury-portal.php';
+
+if ( ! TTP_IS_WPCOM && function_exists( 'register_activation_hook' ) ) {
+    register_activation_hook( TTP_FILE, [ 'Treasury_Tech_Portal', 'instance' ] );
+}
 
 Treasury_Tech_Portal::instance();


### PR DESCRIPTION
## Summary
- replace plugin header with updated metadata
- add version constants and URL/dir definitions
- detect WordPress.com environment and conditionally register activation hook

## Testing
- `php -l treasury-tech-portal.php`


------
https://chatgpt.com/codex/tasks/task_e_689e0d7486a0833198ba6e425b56afd6