### PR TITLE
Add GitHub Actions workflow for WordPress.com deployment validation

### DIFF
--- a/.github/workflows/wordpress-com-deploy.yml
+++ b/.github/workflows/wordpress-com-deploy.yml
@@ -1,0 +1,45 @@
+name: WordPress.com Deploy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - name: Build
+        run: ./scripts/build.sh
+      - name: Test
+        run: ./scripts/test.sh
+
+  validate-structure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify WordPress.com configuration files
+        run: |
+          required_files=(
+            "client-mu-plugins/0-client-mu-plugins.php"
+            "wpcom.yml"
+          )
+          missing=0
+          for file in "${required_files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "Missing required file: $file"
+              missing=1
+            fi
+          done
+          if [ $missing -ne 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for WordPress.com deploy that runs build/test scripts
- check for required WordPress.com configuration files

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689e0d7540dc833195650c9f6c66f8b4