### PR TITLE
Add build and test scripts for WordPress.com deployment pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+echo "Running PHP syntax checks..."
+find "$ROOT_DIR" -name "*.php" -not -path "$ROOT_DIR/vendor/*" -print0 | while IFS= read -r -d '' file; do
+    php -l "$file" >/dev/null || { echo "PHP syntax error in $file"; exit 1; }
+done
+echo "PHP syntax checks passed."
+
+echo "Checking required files..."
+REQUIRED_FILES=( "$ROOT_DIR/treasury-tech-portal.php" "$ROOT_DIR/readme.txt" )
+for f in "${REQUIRED_FILES[@]}"; do
+    if [ ! -f "$f" ]; then
+        echo "Missing required file: $f"
+        exit 1
+    fi
+done
+echo "All required files present."
+
+if command -v terser >/dev/null && [ -f "$ROOT_DIR/assets/js/treasury-portal.js" ]; then
+    echo "Minifying assets..."
+    terser "$ROOT_DIR/assets/js/treasury-portal.js" -c -m -o "$ROOT_DIR/assets/js/treasury-portal.min.js"
+else
+    echo "Skipping asset minification (tooling missing)."
+fi
+
+echo "Build completed."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+echo "Running PHP syntax validation..."
+find "$ROOT_DIR" -name "*.php" -not -path "$ROOT_DIR/vendor/*" -print0 | while IFS= read -r -d '' file; do
+    php -l "$file" >/dev/null || { echo "PHP syntax error in $file"; exit 1; }
+done
+echo "PHP syntax validation passed."
+
+if command -v wp >/dev/null; then
+    echo "Running plugin activation check..."
+    wp plugin deactivate treasury-tech-portal >/dev/null 2>&1 || true
+    if wp plugin activate treasury-tech-portal >/dev/null 2>&1; then
+        echo "Plugin activated successfully."
+    else
+        echo "Plugin activation failed."
+        exit 1
+    fi
+
+    echo "Running shortcode test..."
+    if wp eval 'echo do_shortcode("[treasury_portal]");' >/dev/null 2>&1; then
+        echo "Shortcode executed without fatal errors."
+    else
+        echo "Shortcode execution failed."
+        exit 1
+    fi
+else
+    echo "wp-cli not found; skipping plugin activation and shortcode tests."
+fi
+
+echo "All tests completed."


### PR DESCRIPTION
## Summary
- add build script to run PHP syntax checks, ensure required files, and optionally minify assets
- add test script for syntax validation, plugin activation, and shortcode checks

## Testing
- `./scripts/build.sh`
- `./scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e0d73a8ec8331a2450f4dabcdcee8