### PR TITLE
Add build and test scripts for WordPress.com deployment pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+# PHP syntax check for all PHP files
+find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+
+# Required file checks
+required_files=("treasury-tech-portal.php" "readme.txt" "WORDPRESS-COM-DEPLOYMENT.md")
+for file in "${required_files[@]}"; do
+    if [[ ! -f "$file" ]]; then
+        echo "Required file $file is missing!"
+        exit 1
+    fi
+done
+
+# Optional asset minification
+if command -v npm >/dev/null 2>&1 && [[ -f package.json ]]; then
+    npm run build
+else
+    echo "Skipping asset minification; npm or package.json not found."
+fi
+
+echo "Build completed successfully."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+# PHP syntax validation
+find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
+
+# Basic plugin activation checks and shortcode tests
+if command -v wp >/dev/null 2>&1; then
+    wp plugin activate treasury-tech-portal
+    wp eval 'do_shortcode("[treasury_portal]");'
+    wp plugin deactivate treasury-tech-portal
+else
+    echo "wp-cli not found; skipping plugin activation and shortcode tests."
+fi
+
+echo "Tests completed."


### PR DESCRIPTION
## Summary
- Add build script to run PHP syntax checks, verify required files, and optionally minify assets.
- Add test script performing PHP syntax validation, optional plugin activation via WP-CLI, and shortcode tests.

## Testing
- `./scripts/build.sh`
- `./scripts/test.sh` *(fails plugin activation and shortcode tests if `wp` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e0f01f954833197d01911a19cbe97