### PR TITLE
Add GitHub Actions workflow for WordPress.com deployment validation

### DIFF
--- a/.github/workflows/wordpress-com-deploy.yml
+++ b/.github/workflows/wordpress-com-deploy.yml
@@ -1,0 +1,41 @@
+name: WordPress.com Deploy Validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build
+        run: bash scripts/build.sh
+      - name: Test
+        run: bash scripts/test.sh
+
+  validate-structure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Verify required WordPress.com configuration files
+        run: |
+          required_files=(
+            "WORDPRESS-COM-DEPLOYMENT.md"
+            "readme.txt"
+            "treasury-tech-portal.php"
+          )
+          missing=0
+          for file in "${required_files[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "Missing required file: $file" >&2
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run build and test scripts
- verify required WordPress.com files exist before deployment

## Testing
- `bash scripts/build.sh` *(fails: No such file or directory)*
- `bash scripts/test.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e0f04aa848331a9d22bf8361c0297