### PR TITLE
Add build and test scripts for WordPress.com deployment pipeline

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# PHP syntax check for all PHP files
+echo "Running PHP syntax checks..."
 find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 
-# Required file checks
+echo "Verifying required files exist..."
 required_files=("treasury-tech-portal.php" "readme.txt" "WORDPRESS-COM-DEPLOYMENT.md")
 for file in "${required_files[@]}"; do
     if [[ ! -f "$file" ]]; then
@@ -13,8 +13,8 @@ for file in "${required_files[@]}"; do
     fi
 done
 
-# Optional asset minification
 if command -v npm >/dev/null 2>&1 && [[ -f package.json ]]; then
+    echo "Running npm build..."
     npm run build
 else
     echo "Skipping asset minification; npm or package.json not found."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-# PHP syntax validation
+echo "Running PHP syntax validation..."
 find . -type f -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
 
-# Basic plugin activation checks and shortcode tests
 if command -v wp >/dev/null 2>&1; then
+    echo "Checking plugin activation and shortcode execution..."
     wp plugin activate treasury-tech-portal
     wp eval 'do_shortcode("[treasury_portal]");'
     wp plugin deactivate treasury-tech-portal


### PR DESCRIPTION
## Summary
- update build script to surface progress and run optional npm build
- update test script to clarify syntax validation and optional wp-cli checks

## Testing
- `bash scripts/build.sh`
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e1589a7508331b679d9140d2d2cc1